### PR TITLE
Upgrade jjwt 0.11.2 -> 0.12.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
     implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
     implementation 'org.flywaydb:flyway-core'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
-                'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6',
+                'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 

--- a/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
+++ b/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
@@ -3,13 +3,12 @@ package io.spring.infrastructure.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import java.util.Date;
 import java.util.Optional;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -17,22 +16,20 @@ import org.springframework.stereotype.Component;
 @Component
 public class DefaultJwtService implements JwtService {
   private final SecretKey signingKey;
-  private final SignatureAlgorithm signatureAlgorithm;
   private int sessionTime;
 
   @Autowired
   public DefaultJwtService(
       @Value("${jwt.secret}") String secret, @Value("${jwt.sessionTime}") int sessionTime) {
     this.sessionTime = sessionTime;
-    signatureAlgorithm = SignatureAlgorithm.HS512;
-    this.signingKey = new SecretKeySpec(secret.getBytes(), signatureAlgorithm.getJcaName());
+    this.signingKey = Keys.hmacShaKeyFor(secret.getBytes());
   }
 
   @Override
   public String toToken(User user) {
     return Jwts.builder()
-        .setSubject(user.getId())
-        .setExpiration(expireTimeFromNow())
+        .subject(user.getId())
+        .expiration(expireTimeFromNow())
         .signWith(signingKey)
         .compact();
   }
@@ -40,9 +37,8 @@ public class DefaultJwtService implements JwtService {
   @Override
   public Optional<String> getSubFromToken(String token) {
     try {
-      Jws<Claims> claimsJws =
-          Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token);
-      return Optional.ofNullable(claimsJws.getBody().getSubject());
+      Jws<Claims> claimsJws = Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token);
+      return Optional.ofNullable(claimsJws.getPayload().getSubject());
     } catch (Exception e) {
       return Optional.empty();
     }


### PR DESCRIPTION
## Summary
Bumps `io.jsonwebtoken:jjwt-*` from `0.11.2` to `0.12.6` and migrates `DefaultJwtService` to the new 0.12.x API. All 68 backend tests pass.

API changes in `DefaultJwtService`:
- `Jwts.parserBuilder().setSigningKey(k)` → `Jwts.parser().verifyWith(k)`
- `parseClaimsJws(token)` → `parseSignedClaims(token)`; `.getBody()` → `.getPayload()`
- builder `setSubject`/`setExpiration` → `subject`/`expiration`
- Key construction: `new SecretKeySpec(secret.getBytes(), "HmacSHA512")` → `Keys.hmacShaKeyFor(secret.getBytes())`, dropping the now-deprecated `SignatureAlgorithm`.

Why `Keys.hmacShaKeyFor` instead of pinning `Jwts.SIG.HS512`: 0.12 strictly enforces RFC 7518 key sizes. The existing `DefaultJwtServiceTest` uses a 480-bit secret, which is invalid for HS512. The original 0.11.2 code derived the algorithm from key length (HS512 for the 688-bit prod secret, HS384 for the 480-bit test key); `signWith(signingKey)` + `Keys.hmacShaKeyFor` preserves that exact behavior without weakening prod or modifying the test.

Link to Devin session: https://app.devin.ai/sessions/afc2e312b7044692b8467021b08463c7
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->