### PR TITLE
Replace deprecated mockito-inline 4.0.0 with mockito-core 5.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+ext['mockito.version'] = '5.11.0'
+ext['byte-buddy.version'] = '1.14.12'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {
@@ -79,7 +82,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'

--- a/src/test/java/io/spring/selenium/listeners/TestListener.java
+++ b/src/test/java/io/spring/selenium/listeners/TestListener.java
@@ -1,9 +1,5 @@
 package io.spring.selenium.listeners;
 
-import org.testng.ITestContext;
-import org.testng.ITestListener;
-import org.testng.ITestResult;
-
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -11,97 +7,100 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
 
-/**
- * TestNG listener for generating failure reports.
- */
+/** TestNG listener for generating failure reports. */
 public class TestListener implements ITestListener {
-    
-    private static final String REPORT_DIR = "build/reports/selenium/";
-    
-    private int totalTests = 0;
-    private int passedTests = 0;
-    private int failedTests = 0;
-    private int skippedTests = 0;
-    private StringBuilder failureDetails = new StringBuilder();
-    
-    @Override
-    public void onTestStart(ITestResult result) {
-        totalTests++;
+
+  private static final String REPORT_DIR = "build/reports/selenium/";
+
+  private int totalTests = 0;
+  private int passedTests = 0;
+  private int failedTests = 0;
+  private int skippedTests = 0;
+  private StringBuilder failureDetails = new StringBuilder();
+
+  @Override
+  public void onTestStart(ITestResult result) {
+    totalTests++;
+  }
+
+  @Override
+  public void onTestSuccess(ITestResult result) {
+    passedTests++;
+  }
+
+  @Override
+  public void onTestFailure(ITestResult result) {
+    failedTests++;
+    appendFailureDetails(result);
+  }
+
+  @Override
+  public void onTestSkipped(ITestResult result) {
+    skippedTests++;
+  }
+
+  @Override
+  public void onFinish(ITestContext context) {
+    if (failedTests > 0) {
+      generateFailureReport();
     }
-    
-    @Override
-    public void onTestSuccess(ITestResult result) {
-        passedTests++;
+  }
+
+  private void appendFailureDetails(ITestResult result) {
+    failureDetails.append("\n### ").append(result.getName()).append("\n");
+    failureDetails.append("- **Class:** ").append(result.getTestClass().getName()).append("\n");
+    failureDetails.append("- **Method:** ").append(result.getMethod().getMethodName()).append("\n");
+    failureDetails
+        .append("- **Failure Reason:** ")
+        .append(result.getThrowable().getMessage())
+        .append("\n");
+    failureDetails.append("- **Stack Trace:**\n```\n");
+
+    for (StackTraceElement element : result.getThrowable().getStackTrace()) {
+      failureDetails.append(element.toString()).append("\n");
     }
-    
-    @Override
-    public void onTestFailure(ITestResult result) {
-        failedTests++;
-        appendFailureDetails(result);
+    failureDetails.append("```\n");
+  }
+
+  private void generateFailureReport() {
+    String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+    String reportPath = REPORT_DIR + "failure-report-" + timestamp + ".md";
+
+    try {
+      Files.createDirectories(Paths.get(REPORT_DIR));
+
+      try (PrintWriter writer = new PrintWriter(new FileWriter(reportPath))) {
+        writer.println("# Test Failure Report - " + timestamp);
+        writer.println();
+        writer.println("## Summary");
+        writer.println("- Total Tests: " + totalTests);
+        writer.println("- Passed: " + passedTests);
+        writer.println("- Failed: " + failedTests);
+        writer.println("- Skipped: " + skippedTests);
+        writer.println();
+        writer.println("## Failed Tests");
+        writer.println(failureDetails.toString());
+      }
+
+      // Archive the report
+      archiveReport(reportPath, timestamp);
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-    
-    @Override
-    public void onTestSkipped(ITestResult result) {
-        skippedTests++;
+  }
+
+  private void archiveReport(String reportPath, String timestamp) {
+    try {
+      Files.createDirectories(Paths.get(REPORT_DIR + "archive"));
+      Files.copy(
+          Paths.get(reportPath),
+          Paths.get(REPORT_DIR + "archive/failure-report-" + timestamp + ".md"));
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-    
-    @Override
-    public void onFinish(ITestContext context) {
-        if (failedTests > 0) {
-            generateFailureReport();
-        }
-    }
-    
-    private void appendFailureDetails(ITestResult result) {
-        failureDetails.append("\n### ").append(result.getName()).append("\n");
-        failureDetails.append("- **Class:** ").append(result.getTestClass().getName()).append("\n");
-        failureDetails.append("- **Method:** ").append(result.getMethod().getMethodName()).append("\n");
-        failureDetails.append("- **Failure Reason:** ").append(result.getThrowable().getMessage()).append("\n");
-        failureDetails.append("- **Stack Trace:**\n```\n");
-        
-        for (StackTraceElement element : result.getThrowable().getStackTrace()) {
-            failureDetails.append(element.toString()).append("\n");
-        }
-        failureDetails.append("```\n");
-    }
-    
-    private void generateFailureReport() {
-        String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-        String reportPath = REPORT_DIR + "failure-report-" + timestamp + ".md";
-        
-        try {
-            Files.createDirectories(Paths.get(REPORT_DIR));
-            
-            try (PrintWriter writer = new PrintWriter(new FileWriter(reportPath))) {
-                writer.println("# Test Failure Report - " + timestamp);
-                writer.println();
-                writer.println("## Summary");
-                writer.println("- Total Tests: " + totalTests);
-                writer.println("- Passed: " + passedTests);
-                writer.println("- Failed: " + failedTests);
-                writer.println("- Skipped: " + skippedTests);
-                writer.println();
-                writer.println("## Failed Tests");
-                writer.println(failureDetails.toString());
-            }
-            
-            // Archive the report
-            archiveReport(reportPath, timestamp);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-    
-    private void archiveReport(String reportPath, String timestamp) {
-        try {
-            Files.createDirectories(Paths.get(REPORT_DIR + "archive"));
-            Files.copy(
-                Paths.get(reportPath),
-                Paths.get(REPORT_DIR + "archive/failure-report-" + timestamp + ".md")
-            );
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+  }
 }

--- a/src/test/java/io/spring/selenium/pages/BasePage.java
+++ b/src/test/java/io/spring/selenium/pages/BasePage.java
@@ -6,66 +6,52 @@ import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-/**
- * Base page class providing common functionality for all page objects.
- */
+/** Base page class providing common functionality for all page objects. */
 public abstract class BasePage {
-    
-    protected WebDriver driver;
-    protected WebDriverWait wait;
-    protected static final long DEFAULT_TIMEOUT_SECONDS = 10;
-    
-    public BasePage(WebDriver driver) {
-        this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT_SECONDS);
-        PageFactory.initElements(driver, this);
+
+  protected WebDriver driver;
+  protected WebDriverWait wait;
+  protected static final long DEFAULT_TIMEOUT_SECONDS = 10;
+
+  public BasePage(WebDriver driver) {
+    this.driver = driver;
+    this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT_SECONDS);
+    PageFactory.initElements(driver, this);
+  }
+
+  /** Wait for element to be visible and return it. */
+  protected WebElement waitForVisibility(WebElement element) {
+    return wait.until(ExpectedConditions.visibilityOf(element));
+  }
+
+  /** Wait for element to be clickable and return it. */
+  protected WebElement waitForClickable(WebElement element) {
+    return wait.until(ExpectedConditions.elementToBeClickable(element));
+  }
+
+  /** Click an element after waiting for it to be clickable. */
+  protected void click(WebElement element) {
+    waitForClickable(element).click();
+  }
+
+  /** Type text into an element after clearing it. */
+  protected void type(WebElement element, String text) {
+    WebElement visibleElement = waitForVisibility(element);
+    visibleElement.clear();
+    visibleElement.sendKeys(text);
+  }
+
+  /** Get text from an element after waiting for visibility. */
+  protected String getText(WebElement element) {
+    return waitForVisibility(element).getText();
+  }
+
+  /** Check if element is displayed. */
+  protected boolean isDisplayed(WebElement element) {
+    try {
+      return element.isDisplayed();
+    } catch (Exception e) {
+      return false;
     }
-    
-    /**
-     * Wait for element to be visible and return it.
-     */
-    protected WebElement waitForVisibility(WebElement element) {
-        return wait.until(ExpectedConditions.visibilityOf(element));
-    }
-    
-    /**
-     * Wait for element to be clickable and return it.
-     */
-    protected WebElement waitForClickable(WebElement element) {
-        return wait.until(ExpectedConditions.elementToBeClickable(element));
-    }
-    
-    /**
-     * Click an element after waiting for it to be clickable.
-     */
-    protected void click(WebElement element) {
-        waitForClickable(element).click();
-    }
-    
-    /**
-     * Type text into an element after clearing it.
-     */
-    protected void type(WebElement element, String text) {
-        WebElement visibleElement = waitForVisibility(element);
-        visibleElement.clear();
-        visibleElement.sendKeys(text);
-    }
-    
-    /**
-     * Get text from an element after waiting for visibility.
-     */
-    protected String getText(WebElement element) {
-        return waitForVisibility(element).getText();
-    }
-    
-    /**
-     * Check if element is displayed.
-     */
-    protected boolean isDisplayed(WebElement element) {
-        try {
-            return element.isDisplayed();
-        } catch (Exception e) {
-            return false;
-        }
-    }
+  }
 }

--- a/src/test/java/io/spring/selenium/tests/BaseTest.java
+++ b/src/test/java/io/spring/selenium/tests/BaseTest.java
@@ -5,17 +5,6 @@ import com.aventstack.extentreports.ExtentTest;
 import com.aventstack.extentreports.reporter.ExtentSparkReporter;
 import com.aventstack.extentreports.reporter.configuration.Theme;
 import io.github.bonigarcia.wdm.WebDriverManager;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.OutputType;
-import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.edge.EdgeDriver;
-import org.testng.ITestResult;
-import org.testng.annotations.*;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,214 +19,222 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Properties;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.testng.ITestResult;
+import org.testng.annotations.*;
 
-/**
- * Base test class providing WebDriver setup, teardown, and reporting.
- */
+/** Base test class providing WebDriver setup, teardown, and reporting. */
 public abstract class BaseTest {
-    
-    protected WebDriver driver;
-    protected static ExtentReports extent;
-    protected ExtentTest test;
-    protected static Properties config;
-    
-    private static final String CONFIG_PATH = "src/test/resources/selenium/config.properties";
-    private static final String REPORT_PATH = "build/reports/selenium/ExtentReport.html";
-    private static final String SCREENSHOT_PATH = "build/reports/selenium/screenshots/";
-    
-    @BeforeSuite
-    public void setupSuite() {
-        loadConfig();
-        setupExtentReports();
-        createDirectories();
+
+  protected WebDriver driver;
+  protected static ExtentReports extent;
+  protected ExtentTest test;
+  protected static Properties config;
+
+  private static final String CONFIG_PATH = "src/test/resources/selenium/config.properties";
+  private static final String REPORT_PATH = "build/reports/selenium/ExtentReport.html";
+  private static final String SCREENSHOT_PATH = "build/reports/selenium/screenshots/";
+
+  @BeforeSuite
+  public void setupSuite() {
+    loadConfig();
+    setupExtentReports();
+    createDirectories();
+  }
+
+  @BeforeMethod
+  public void setupTest() {
+    initializeDriver();
+    driver.manage().window().maximize();
+    // Don't navigate to base URL in setup - let individual tests handle navigation
+  }
+
+  @AfterMethod
+  public void teardownTest(ITestResult result) {
+    if (result.getStatus() == ITestResult.FAILURE) {
+      captureScreenshot(result.getName());
+      test.fail("Test failed: " + result.getThrowable().getMessage());
+    } else if (result.getStatus() == ITestResult.SUCCESS) {
+      test.pass("Test passed");
+    } else {
+      test.skip("Test skipped");
     }
-    
-    @BeforeMethod
-    public void setupTest() {
-        initializeDriver();
-        driver.manage().window().maximize();
-        // Don't navigate to base URL in setup - let individual tests handle navigation
+
+    // Don't quit the driver when using Devin's browser - it would close Devin's browser instance
+    boolean useDevinBrowser =
+        Boolean.parseBoolean(config.getProperty("devin.browser.enabled", "false"));
+    if (driver != null && !useDevinBrowser) {
+      driver.quit();
     }
-    
-    @AfterMethod
-    public void teardownTest(ITestResult result) {
-        if (result.getStatus() == ITestResult.FAILURE) {
-            captureScreenshot(result.getName());
-            test.fail("Test failed: " + result.getThrowable().getMessage());
-        } else if (result.getStatus() == ITestResult.SUCCESS) {
-            test.pass("Test passed");
-        } else {
-            test.skip("Test skipped");
-        }
-        
-        // Don't quit the driver when using Devin's browser - it would close Devin's browser instance
-        boolean useDevinBrowser = Boolean.parseBoolean(config.getProperty("devin.browser.enabled", "false"));
-        if (driver != null && !useDevinBrowser) {
-            driver.quit();
-        }
+  }
+
+  @AfterSuite
+  public void teardownSuite() {
+    if (extent != null) {
+      extent.flush();
     }
-    
-    @AfterSuite
-    public void teardownSuite() {
-        if (extent != null) {
-            extent.flush();
-        }
+  }
+
+  private void loadConfig() {
+    config = new Properties();
+    try {
+      File configFile = new File(CONFIG_PATH);
+      if (configFile.exists()) {
+        config.load(new FileInputStream(configFile));
+      }
+    } catch (IOException e) {
+      System.out.println("Config file not found, using defaults");
     }
-    
-    private void loadConfig() {
-        config = new Properties();
-        try {
-            File configFile = new File(CONFIG_PATH);
-            if (configFile.exists()) {
-                config.load(new FileInputStream(configFile));
-            }
-        } catch (IOException e) {
-            System.out.println("Config file not found, using defaults");
-        }
+  }
+
+  private void setupExtentReports() {
+    ExtentSparkReporter sparkReporter = new ExtentSparkReporter(REPORT_PATH);
+    sparkReporter.config().setTheme(Theme.STANDARD);
+    sparkReporter.config().setDocumentTitle("Selenium Test Report");
+    sparkReporter.config().setReportName("Test Execution Report");
+
+    extent = new ExtentReports();
+    extent.attachReporter(sparkReporter);
+    extent.setSystemInfo("OS", System.getProperty("os.name"));
+    extent.setSystemInfo("Java Version", System.getProperty("java.version"));
+  }
+
+  private void createDirectories() {
+    try {
+      Files.createDirectories(Paths.get(SCREENSHOT_PATH));
+      Files.createDirectories(Paths.get("build/reports/selenium/archive"));
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-    
-    private void setupExtentReports() {
-        ExtentSparkReporter sparkReporter = new ExtentSparkReporter(REPORT_PATH);
-        sparkReporter.config().setTheme(Theme.STANDARD);
-        sparkReporter.config().setDocumentTitle("Selenium Test Report");
-        sparkReporter.config().setReportName("Test Execution Report");
-        
-        extent = new ExtentReports();
-        extent.attachReporter(sparkReporter);
-        extent.setSystemInfo("OS", System.getProperty("os.name"));
-        extent.setSystemInfo("Java Version", System.getProperty("java.version"));
+  }
+
+  private void initializeDriver() {
+    String browser = config.getProperty("browser", "chrome").toLowerCase();
+    boolean useDevinBrowser =
+        Boolean.parseBoolean(config.getProperty("devin.browser.enabled", "false"));
+
+    if (useDevinBrowser) {
+      initializeDevinBrowser();
+      return;
     }
-    
-    private void createDirectories() {
-        try {
-            Files.createDirectories(Paths.get(SCREENSHOT_PATH));
-            Files.createDirectories(Paths.get("build/reports/selenium/archive"));
-        } catch (IOException e) {
-            e.printStackTrace();
+
+    switch (browser) {
+      case "firefox":
+        WebDriverManager.firefoxdriver().setup();
+        driver = new FirefoxDriver();
+        break;
+      case "edge":
+        WebDriverManager.edgedriver().setup();
+        driver = new EdgeDriver();
+        break;
+      case "chrome":
+      default:
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions options = new ChromeOptions();
+        if (Boolean.parseBoolean(config.getProperty("headless", "false"))) {
+          options.addArguments("--headless");
         }
+        driver = new ChromeDriver(options);
+        break;
     }
-    
-    private void initializeDriver() {
-        String browser = config.getProperty("browser", "chrome").toLowerCase();
-        boolean useDevinBrowser = Boolean.parseBoolean(config.getProperty("devin.browser.enabled", "false"));
-        
-        if (useDevinBrowser) {
-            initializeDevinBrowser();
-            return;
-        }
-        
-        switch (browser) {
-            case "firefox":
-                WebDriverManager.firefoxdriver().setup();
-                driver = new FirefoxDriver();
-                break;
-            case "edge":
-                WebDriverManager.edgedriver().setup();
-                driver = new EdgeDriver();
-                break;
-            case "chrome":
-            default:
-                WebDriverManager.chromedriver().setup();
-                ChromeOptions options = new ChromeOptions();
-                if (Boolean.parseBoolean(config.getProperty("headless", "false"))) {
-                    options.addArguments("--headless");
-                }
-                driver = new ChromeDriver(options);
-                break;
-        }
+  }
+
+  /**
+   * Initialize WebDriver to connect to Devin's Chrome browser instance. Devin runs Chrome with
+   * specific automation flags and exposes it via remote debugging.
+   */
+  private void initializeDevinBrowser() {
+    try {
+      int browserPort = getDevinBrowserPort();
+
+      ChromeOptions options = new ChromeOptions();
+
+      // Connect to existing Chrome instance via remote debugging
+      options.setExperimentalOption("debuggerAddress", "127.0.0.1:" + browserPort);
+
+      // Match Devin's user agent for consistency
+      options.addArguments(
+          "--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+              + "(KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36; Devin/1.0; +devin.ai");
+
+      WebDriverManager.chromedriver().setup();
+      driver = new ChromeDriver(options);
+
+      // Set viewport to match Devin's configuration
+      driver.manage().window().setSize(new Dimension(1550, 1122));
+
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to connect to Devin's browser: " + e.getMessage(), e);
     }
-    
-    /**
-     * Initialize WebDriver to connect to Devin's Chrome browser instance.
-     * Devin runs Chrome with specific automation flags and exposes it via remote debugging.
-     */
-    private void initializeDevinBrowser() {
-        try {
-            int browserPort = getDevinBrowserPort();
-            
-            ChromeOptions options = new ChromeOptions();
-            
-            // Connect to existing Chrome instance via remote debugging
-            options.setExperimentalOption("debuggerAddress", "127.0.0.1:" + browserPort);
-            
-            // Match Devin's user agent for consistency
-            options.addArguments(
-                "--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
-                "(KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36; Devin/1.0; +devin.ai"
-            );
-            
-            WebDriverManager.chromedriver().setup();
-            driver = new ChromeDriver(options);
-            
-            // Set viewport to match Devin's configuration
-            driver.manage().window().setSize(new Dimension(1550, 1122));
-            
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to connect to Devin's browser: " + e.getMessage(), e);
-        }
+  }
+
+  /**
+   * Get the browser port from Devin's browser service. Devin's browser runs on ports starting from
+   * 32500.
+   */
+  private int getDevinBrowserPort() throws IOException {
+    String devinBrowserServiceUrl =
+        config.getProperty(
+            "devin.browser.service.url", "http://localhost:3000/browser/start_browser");
+
+    URL url = new URL(devinBrowserServiceUrl);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestMethod("POST");
+    conn.setRequestProperty("Content-Type", "application/json");
+    conn.setDoOutput(true);
+
+    // Send request body
+    String jsonBody = "{\"frpConfig\": null}";
+    try (OutputStream os = conn.getOutputStream()) {
+      os.write(jsonBody.getBytes());
     }
-    
-    /**
-     * Get the browser port from Devin's browser service.
-     * Devin's browser runs on ports starting from 32500.
-     */
-    private int getDevinBrowserPort() throws IOException {
-        String devinBrowserServiceUrl = config.getProperty(
-            "devin.browser.service.url", 
-            "http://localhost:3000/browser/start_browser"
-        );
-        
-        URL url = new URL(devinBrowserServiceUrl);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setDoOutput(true);
-        
-        // Send request body
-        String jsonBody = "{\"frpConfig\": null}";
-        try (OutputStream os = conn.getOutputStream()) {
-            os.write(jsonBody.getBytes());
-        }
-        
-        if (conn.getResponseCode() != 200) {
-            throw new IOException("Failed to get browser port. Response code: " + conn.getResponseCode());
-        }
-        
-        // Parse response to get port
-        StringBuilder response = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                response.append(line);
-            }
-        }
-        
-        // Simple JSON parsing for port (avoid adding JSON library dependency)
-        String responseStr = response.toString();
-        int portIndex = responseStr.indexOf("\"port\":");
-        if (portIndex == -1) {
-            throw new IOException("Port not found in response: " + responseStr);
-        }
-        
-        String portStr = responseStr.substring(portIndex + 7).split("[,}]")[0].trim();
-        return Integer.parseInt(portStr);
+
+    if (conn.getResponseCode() != 200) {
+      throw new IOException("Failed to get browser port. Response code: " + conn.getResponseCode());
     }
-    
-    protected void captureScreenshot(String testName) {
-        try {
-            TakesScreenshot ts = (TakesScreenshot) driver;
-            byte[] screenshot = ts.getScreenshotAs(OutputType.BYTES);
-            String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-            Path destination = Paths.get(SCREENSHOT_PATH + testName + "_" + timestamp + ".png");
-            Files.write(destination, screenshot);
-            test.addScreenCaptureFromPath(destination.toString());
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+
+    // Parse response to get port
+    StringBuilder response = new StringBuilder();
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        response.append(line);
+      }
     }
-    
-    protected ExtentTest createTest(String testName, String description) {
-        test = extent.createTest(testName, description);
-        return test;
+
+    // Simple JSON parsing for port (avoid adding JSON library dependency)
+    String responseStr = response.toString();
+    int portIndex = responseStr.indexOf("\"port\":");
+    if (portIndex == -1) {
+      throw new IOException("Port not found in response: " + responseStr);
     }
+
+    String portStr = responseStr.substring(portIndex + 7).split("[,}]")[0].trim();
+    return Integer.parseInt(portStr);
+  }
+
+  protected void captureScreenshot(String testName) {
+    try {
+      TakesScreenshot ts = (TakesScreenshot) driver;
+      byte[] screenshot = ts.getScreenshotAs(OutputType.BYTES);
+      String timestamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+      Path destination = Paths.get(SCREENSHOT_PATH + testName + "_" + timestamp + ".png");
+      Files.write(destination, screenshot);
+      test.addScreenCaptureFromPath(destination.toString());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  protected ExtentTest createTest(String testName, String description) {
+    test = extent.createTest(testName, description);
+    return test;
+  }
 }

--- a/src/test/java/io/spring/selenium/tests/SeleniumSetupTest.java
+++ b/src/test/java/io/spring/selenium/tests/SeleniumSetupTest.java
@@ -1,35 +1,34 @@
 package io.spring.selenium.tests;
 
-import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
-/**
- * Simple test to verify Selenium setup is working correctly.
- */
+import org.testng.annotations.Test;
+
+/** Simple test to verify Selenium setup is working correctly. */
 public class SeleniumSetupTest extends BaseTest {
-    
-    @Test(groups = {"smoke"})
-    public void testBrowserLaunches() {
-        createTest("testBrowserLaunches", "Verify browser launches and can navigate");
-        
-        // Navigate to a simple page
-        driver.get("https://www.google.com");
-        
-        // Verify we got a page title
-        String title = driver.getTitle();
-        assertNotNull(title, "Page title should not be null");
-        assertTrue(title.length() > 0, "Page title should not be empty");
-        
-        test.info("Successfully navigated to Google. Title: " + title);
-    }
-    
-    @Test(groups = {"smoke"})
-    public void testWebDriverManagerSetup() {
-        createTest("testWebDriverManagerSetup", "Verify WebDriverManager configured the driver");
-        
-        // If we get here, WebDriverManager successfully set up the driver
-        assertNotNull(driver, "WebDriver should be initialized");
-        
-        test.info("WebDriver successfully initialized: " + driver.getClass().getSimpleName());
-    }
+
+  @Test(groups = {"smoke"})
+  public void testBrowserLaunches() {
+    createTest("testBrowserLaunches", "Verify browser launches and can navigate");
+
+    // Navigate to a simple page
+    driver.get("https://www.google.com");
+
+    // Verify we got a page title
+    String title = driver.getTitle();
+    assertNotNull(title, "Page title should not be null");
+    assertTrue(title.length() > 0, "Page title should not be empty");
+
+    test.info("Successfully navigated to Google. Title: " + title);
+  }
+
+  @Test(groups = {"smoke"})
+  public void testWebDriverManagerSetup() {
+    createTest("testWebDriverManagerSetup", "Verify WebDriverManager configured the driver");
+
+    // If we get here, WebDriverManager successfully set up the driver
+    assertNotNull(driver, "WebDriver should be initialized");
+
+    test.info("WebDriver successfully initialized: " + driver.getClass().getSimpleName());
+  }
 }


### PR DESCRIPTION
## Summary

The `mockito-inline` artifact is deprecated — Mockito 5.x ships the inline mock maker as the default in `mockito-core`, making the separate artifact unnecessary.

**Changes in `build.gradle`:**
```diff
- testImplementation 'org.mockito:mockito-inline:4.0.0'
+ testImplementation 'org.mockito:mockito-core:5.11.0'
+ testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
```

Spring Boot 2.6.3's BOM manages `mockito` at 4.0.0 and `byte-buddy` at 1.11.22, which conflicts with Mockito 5.x's requirement for ByteBuddy 1.14.12. Overridden via `ext` properties:
```groovy
ext['mockito.version'] = '5.11.0'
ext['byte-buddy.version'] = '1.14.12'
```

No test code changes required — all 68 tests pass. Includes pre-existing Spotless formatting fixes for Selenium test files.

Link to Devin session: https://app.devin.ai/sessions/8a1fbbd78ef54cfa823ec3f08d5e2cca
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->