### PR TITLE
Upgrade Mockito from mockito-inline 4.0.0 to mockito-core 5.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+// Override Spring Boot BOM-pinned versions to upgrade Mockito to 5.x
+ext['mockito.version'] = '5.11.0'
+ext['byte-buddy.version'] = '1.14.12'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {
@@ -79,7 +83,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
+    testImplementation 'org.mockito:mockito-core'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'


### PR DESCRIPTION
## Summary
Upgrades Mockito `4.0.0 -> 5.11.0`. In Mockito 5.x the inline mock maker is the default in `mockito-core`, so the separate `mockito-inline` artifact is removed/merged. All changes are confined to `build.gradle` — no test source changes were needed.

```diff
- testImplementation 'org.mockito:mockito-inline:4.0.0'
+ testImplementation 'org.mockito:mockito-core'
+ ext['mockito.version']    = '5.11.0'
+ ext['byte-buddy.version'] = '1.14.12'
```

## API changes
- None in source. The tests only use `org.mockito.ArgumentMatchers.*` (`any`, `eq`, `anyString`) and `org.mockito.Mockito.when/verify`, all of which are unchanged in 5.x. No `mockStatic`/`MockedStatic`/`Mockito.framework()` or removed-matcher (`org.mockito.Matchers`) usage exists.

## Notes / why
- **BOM override required:** Spring Boot 2.6.3's dependency-management BOM pins `mockito.version`. Editing the coordinate alone has no effect — the BOM wins — so `ext['mockito.version'] = '5.11.0'` is set to force resolution.
- **byte-buddy:** Mockito 5.x needs byte-buddy 1.14.x+; `ext['byte-buddy.version'] = '1.14.12'` overrides the older BOM-pinned value.
- `mockito-core` itself is no longer version-pinned in the dependency block because it's supplied transitively via `spring-boot-starter-test` and now resolves through the `mockito.version` property.
- Verified resolution via `./gradlew dependencyInsight --dependency org.mockito --configuration testRuntimeClasspath` → `org.mockito:mockito-core:5.11.0`; byte-buddy → `1.14.12`.
- `./gradlew clean test -x jacocoTestCoverageVerification` passes all **68** tests (same as the pre-upgrade baseline).

Link to Devin session: https://app.devin.ai/sessions/24c60befd9434986a8477e8c8b639199
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->