### PR TITLE
Upgrade jjwt 0.11.2 → 0.12.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
     implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
     implementation 'org.flywaydb:flyway-core'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
-                'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6',
+                'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 

--- a/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
+++ b/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
@@ -3,13 +3,12 @@ package io.spring.infrastructure.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import java.util.Date;
 import java.util.Optional;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -17,22 +16,20 @@ import org.springframework.stereotype.Component;
 @Component
 public class DefaultJwtService implements JwtService {
   private final SecretKey signingKey;
-  private final SignatureAlgorithm signatureAlgorithm;
   private int sessionTime;
 
   @Autowired
   public DefaultJwtService(
       @Value("${jwt.secret}") String secret, @Value("${jwt.sessionTime}") int sessionTime) {
     this.sessionTime = sessionTime;
-    signatureAlgorithm = SignatureAlgorithm.HS512;
-    this.signingKey = new SecretKeySpec(secret.getBytes(), signatureAlgorithm.getJcaName());
+    this.signingKey = Keys.hmacShaKeyFor(secret.getBytes());
   }
 
   @Override
   public String toToken(User user) {
     return Jwts.builder()
-        .setSubject(user.getId())
-        .setExpiration(expireTimeFromNow())
+        .subject(user.getId())
+        .expiration(expireTimeFromNow())
         .signWith(signingKey)
         .compact();
   }
@@ -40,9 +37,8 @@ public class DefaultJwtService implements JwtService {
   @Override
   public Optional<String> getSubFromToken(String token) {
     try {
-      Jws<Claims> claimsJws =
-          Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token);
-      return Optional.ofNullable(claimsJws.getBody().getSubject());
+      Jws<Claims> claimsJws = Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token);
+      return Optional.ofNullable(claimsJws.getPayload().getSubject());
     } catch (Exception e) {
       return Optional.empty();
     }


### PR DESCRIPTION
## Summary
Upgrades the `io.jsonwebtoken` (jjwt) family from `0.11.2` → `0.12.6` (`jjwt-api`, `jjwt-impl`, `jjwt-jackson`) and migrates `DefaultJwtService` to the 0.12 API. Only JWT usage was in `DefaultJwtService`; no test files referenced the jjwt API.

## API changes (`DefaultJwtService`)
- Builder: `setSubject()` → `subject()`, `setExpiration()` → `expiration()`
- Parsing: `Jwts.parserBuilder().setSigningKey(k).build().parseClaimsJws(t)` → `Jwts.parser().verifyWith(k).build().parseSignedClaims(t)`
- Claims access: `.getBody()` → `.getPayload()`
- Key creation: `new SecretKeySpec(secret.getBytes(), "HmacSHA512")` → `Keys.hmacShaKeyFor(secret.getBytes())` (dropped deprecated `SignatureAlgorithm`)

## Notes / why
- jjwt 0.12 enforces RFC 7518 minimum key sizes. The production secret in `application.properties` is 86 bytes (688 bits) so it still resolves to HS512 with identical bytes — **production token behavior is unchanged**.
- `DefaultJwtServiceTest` injects a 60-byte (480-bit) secret that is too weak for HS512 under the new strict validation. Using `Keys.hmacShaKeyFor(...)` lets the service pick a valid algorithm for the key length (HS384 for the 480-bit test key) instead of throwing `UnsupportedKeyException`. This fixes the test **without rewriting the test and without weakening production** (the 688-bit prod key still uses HS512).
- `dependencyInsight` confirms `jjwt-api:0.12.6` resolves on `runtimeClasspath` (not BOM-pinned).
- All 68 backend tests pass via `./gradlew clean test -x jacocoTestCoverageVerification` (matches pre-upgrade baseline).

Link to Devin session: https://app.devin.ai/sessions/bda7d12c55f444ac8590b547454cd436
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->