### PR TITLE
chore: upgrade sqlite-jdbc from 3.36.0.3 to 3.49.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation 'joda-time:joda-time:2.10.13'
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary

Bumps `org.xerial:sqlite-jdbc` from `3.36.0.3` → `3.49.1.0` in `build.gradle`.

**No breaking API changes** — the codebase doesn't import any `org.sqlite.*` classes directly; it only references the driver via Spring DataSource config (`spring.datasource.driver-class-name=org.sqlite.JDBC`). The driver class name and `jdbc:sqlite:` URL format are unchanged.

**Verification:**
- `dependencyInsight` confirms `3.49.1.0` resolved (no BOM override).
- `spotlessApply` clean — no formatting changes needed.
- All **68 tests** pass (`./gradlew clean test -x jacocoTestCoverageVerification`).

Link to Devin session: https://app.devin.ai/sessions/b7f6fe045b45450aa5a23756d7f8cb91
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->