### PR TITLE
chore: upgrade httpclient5 from 5.2.1 to 5.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
     testImplementation 'org.testng:testng:7.8.0'
     testImplementation 'com.aventstack:extentreports:5.1.1'
-    testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+    testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.6.1'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## Summary

Bumps `org.apache.httpcomponents.client5:httpclient5` from `5.2.1` → `5.6.1` in `build.gradle`.

This dependency is used only by the Selenium E2E test infrastructure (transitive via `webdrivermanager` / `docker-java-transport-httpclient5`). No source code in `src/main` or `src/test` imports httpclient5 APIs directly, so no API migration was needed.

- **Verified resolved version**: `dependencyInsight` confirms `5.6.1` is resolved (no Spring Boot BOM override).
- **All 68 JUnit 5 tests pass** (`./gradlew clean test -x jacocoTestCoverageVerification`).
- **Spotless**: clean after `spotlessApply`.

Link to Devin session: https://app.devin.ai/sessions/804aac355b2c4c5c9d4fc619d7fbfe55
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->