### PR TITLE
Upgrade Mockito 4.0.0 → 5.2.0 (mockito-inline → mockito-core)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+ext['mockito.version'] = '5.2.0'
+ext['byte-buddy.version'] = '1.14.12'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {
@@ -79,7 +82,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
+    testImplementation 'org.mockito:mockito-core:5.2.0'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'


### PR DESCRIPTION
## Summary\n\nUpgrades Mockito from 4.0.0 to 5.2.0 by replacing the deprecated `mockito-inline` artifact with `mockito-core` (the inline mock maker is now the default in Mockito 5.x).\n\n**Dependency change:**\n```diff\n- testImplementation 'org.mockito:mockito-inline:4.0.0'\n+ testImplementation 'org.mockito:mockito-core:5.2.0'\n```\n\n**BOM overrides** (Spring Boot 2.6.3 BOM pins mockito to 4.0.0):\n```gradle\next['mockito.version'] = '5.2.0'\next['byte-buddy.version'] = '1.14.12'\n```\n\n**API changes:** None required — all 68 tests pass without source modifications. The test code uses only stable Mockito APIs (`when`, `verify`, matchers) that are unchanged between 4.x and 5.x.\n\n**Why byte-buddy override:** Mockito 5.2.0 depends on byte-buddy 1.14.x, while the Spring Boot BOM pins an older version that is incompatible.

Link to Devin session: https://app.devin.ai/sessions/3e8db940e0384c9b99c8c7dc1fea6d91
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->