### PR TITLE
Upgrade TestNG from 7.8.0 to 7.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
-    testImplementation 'org.testng:testng:7.8.0'
+    testImplementation 'org.testng:testng:7.11.0'
     testImplementation 'com.aventstack:extentreports:5.1.1'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 }


### PR DESCRIPTION
## Summary

Bumps `org.testng:testng` from **7.8.0** → **7.11.0** in `build.gradle`.

TestNG is used only for the Selenium E2E tests (`src/test/java/io/spring/selenium/`). The APIs consumed — `@Test`, `@BeforeSuite`/`@BeforeMethod`/`@AfterMethod`/`@AfterSuite`, `ITestListener`, `ITestResult`, `ITestContext`, `Assert.*` — are all stable across this version range, so **no source changes were required**.

Changes in TestNG 7.9–7.11 are internal: thread-pool streamlining, XML serialisation improvements, JCommander/SLF4J dependency bumps, and bug fixes. No breaking API changes affect this project.

**Verification:**
- `dependencyInsight` confirms 7.11.0 resolved (not overridden by Spring Boot BOM).
- `./gradlew spotlessApply` — clean, no formatting changes needed.
- `./gradlew assemble` — compiles successfully.
- `./gradlew clean test -x jacocoTestCoverageVerification` — all **68 tests pass**, 0 failures, 0 skipped.

Link to Devin session: https://app.devin.ai/sessions/29249d460fbf4d8a8635725768cba4ef
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->