### PR TITLE
Upgrade webdrivermanager from 5.6.2 to 6.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
-    testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
+    testImplementation 'io.github.bonigarcia:webdrivermanager:6.1.0'
     testImplementation 'org.testng:testng:7.8.0'
     testImplementation 'com.aventstack:extentreports:5.1.1'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'


### PR DESCRIPTION
## Summary

Bump `io.github.bonigarcia:webdrivermanager` from **5.6.2 → 6.1.0** in `build.gradle`.

No API changes required — the `WebDriverManager.chromedriver().setup()` / `firefoxdriver().setup()` / `edgedriver().setup()` pattern used in `BaseTest.java` is unchanged in 6.x.

### What's new in 6.x (highlights)

- Docker support switched to docker-selenium images (ARM64 included)
- New `browserBinary()` and `getRecordingPath()` API methods
- BrowserWatcher 2.0.0 (MV3) for video recording
- `LoggingPreferences` for log gathering in Chromium-based browsers
- Various edgedriver/geckodriver fixes

### Verification

- `./gradlew dependencyInsight --dependency webdrivermanager` resolves to 6.1.0
- `./gradlew assemble` compiles all source including Selenium test classes
- `./gradlew clean test -x jacocoTestCoverageVerification` — all 68 tests pass (0 failures, 0 skipped)

Link to Devin session: https://app.devin.ai/sessions/ee2abc8519bf497585cc15fc6fc17373
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->