### PR TITLE
Upgrade from mockito-inline 4.0.0 to mockito-core 5.14.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+ext['mockito.version'] = '5.14.2'
+ext['byte-buddy.version'] = '1.15.4'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {
@@ -79,7 +82,6 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'


### PR DESCRIPTION
## Summary

Replaces the deprecated `mockito-inline:4.0.0` artifact with `mockito-core:5.14.2`. Mockito 5.x ships the inline mock maker by default, making the standalone `mockito-inline` artifact unnecessary.

Changes in `build.gradle`:
- Removed `testImplementation 'org.mockito:mockito-inline:4.0.0'`
- Added `ext['mockito.version'] = '5.14.2'` to override the Spring Boot 2.6.3 BOM (which manages mockito at 4.0.0)
- Added `ext['byte-buddy.version'] = '1.15.4'` — required because Mockito 5.x depends on byte-buddy 1.15.4, but the Spring Boot BOM pins it at 1.11.22 which causes `NoSuchFieldError` at runtime

All 68 tests pass. No test code changes required — the existing `@MockBean`, `when/thenReturn`, `verify` patterns are fully compatible with Mockito 5.x.

Link to Devin session: https://app.devin.ai/sessions/01df3ac21e7542ba93d85e4c170a3999
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->