### PR TITLE
Upgrade jjwt from 0.11.2 to 0.12.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
     implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
     implementation 'org.flywaydb:flyway-core'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
-                'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6',
+                'io.jsonwebtoken:jjwt-jackson:0.12.6'
     implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 

--- a/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
+++ b/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
@@ -3,13 +3,12 @@ package io.spring.infrastructure.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import java.util.Date;
 import java.util.Optional;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -17,22 +16,20 @@ import org.springframework.stereotype.Component;
 @Component
 public class DefaultJwtService implements JwtService {
   private final SecretKey signingKey;
-  private final SignatureAlgorithm signatureAlgorithm;
   private int sessionTime;
 
   @Autowired
   public DefaultJwtService(
       @Value("${jwt.secret}") String secret, @Value("${jwt.sessionTime}") int sessionTime) {
     this.sessionTime = sessionTime;
-    signatureAlgorithm = SignatureAlgorithm.HS512;
-    this.signingKey = new SecretKeySpec(secret.getBytes(), signatureAlgorithm.getJcaName());
+    this.signingKey = Keys.hmacShaKeyFor(secret.getBytes());
   }
 
   @Override
   public String toToken(User user) {
     return Jwts.builder()
-        .setSubject(user.getId())
-        .setExpiration(expireTimeFromNow())
+        .subject(user.getId())
+        .expiration(expireTimeFromNow())
         .signWith(signingKey)
         .compact();
   }
@@ -40,9 +37,8 @@ public class DefaultJwtService implements JwtService {
   @Override
   public Optional<String> getSubFromToken(String token) {
     try {
-      Jws<Claims> claimsJws =
-          Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token);
-      return Optional.ofNullable(claimsJws.getBody().getSubject());
+      Jws<Claims> claimsJws = Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token);
+      return Optional.ofNullable(claimsJws.getPayload().getSubject());
     } catch (Exception e) {
       return Optional.empty();
     }


### PR DESCRIPTION
## Summary
Bumps `io.jsonwebtoken:jjwt-*` from `0.11.2` to `0.12.6` and migrates `DefaultJwtService` to the 0.12.x builder/parser API. All 68 backend tests pass.

The 0.12.x release renamed the fluent builder/parser methods and tightened key handling:

```
// build
Jwts.builder().setSubject(..).setExpiration(..)   -> .subject(..).expiration(..)

// parse
Jwts.parserBuilder().setSigningKey(k).build()
    .parseClaimsJws(t).getBody()                  -> Jwts.parser().verifyWith(k).build()
                                                       .parseSignedClaims(t).getPayload()
```

Key construction also changed. The old code forced an `HmacSHA512` `SecretKeySpec` and relied on `signWith(key)` auto-detecting the algorithm. Under 0.12.x this throws `UnsupportedKeyException` when the key is shorter than 512 bits (the unit test uses a 480-bit secret). Switching to `Keys.hmacShaKeyFor(secret.getBytes())` selects the algorithm by key size — HS384 for the 480-bit test key, HS512 for the 680-bit production secret — preserving the original behavior without modifying the test. `SignatureAlgorithm` is no longer referenced.

Link to Devin session: https://app.devin.ai/sessions/2476a608f905401ca419bd736f3e90a9
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->