### PR TITLE
Upgrade mockito-inline 4.0.0 to mockito-core 5.14.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+// Upgrade Mockito to 5.x for the whole BOM so mockito-core and mockito-junit-jupiter stay in sync.
+ext['mockito.version'] = '5.14.2'
 // Mockito 5.x requires a newer Byte Buddy than the one managed by the Spring Boot BOM.
 ext['byte-buddy.version'] = '1.15.4'
 
@@ -82,7 +84,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-core:5.14.2'
+    testImplementation 'org.mockito:mockito-core'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+// Mockito 5.x requires a newer Byte Buddy than the one managed by the Spring Boot BOM.
+ext['byte-buddy.version'] = '1.15.4'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {
@@ -79,7 +82,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
+    testImplementation 'org.mockito:mockito-core:5.14.2'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'


### PR DESCRIPTION
## Summary
The `mockito-inline` artifact is deprecated as of Mockito 5 (the inline mock maker is now the default in `mockito-core`). This swaps it for `mockito-core` 5.14.2.

```diff
- testImplementation 'org.mockito:mockito-inline:4.0.0'
+ testImplementation 'org.mockito:mockito-core:5.14.2'
```

Mockito 5.x fails to initialize its inline mock maker against the Byte Buddy version that the Spring Boot 2.6.3 BOM pins (`1.11.22`), throwing `MockitoInitializationException` → `NoSuchFieldError` in `PremainAttachAccess` (60/68 tests failed before this fix). Overriding the BOM-managed version resolves it:

```groovy
ext['byte-buddy.version'] = '1.15.4'
```

No test source changes were needed — the suite only uses standard `ArgumentMatchers`/`Mockito` APIs (no static/construction mocking, no removed matchers).

All 68 backend tests pass (`./gradlew clean test`). The pre-existing Spotless violations in `src/test/java/io/spring/selenium/**` are unrelated to this change (present on `master`).

Link to Devin session: https://app.devin.ai/sessions/24e0d96085ed463db88a39d687217077
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->