### PR TITLE
Upgrade org.xerial:sqlite-jdbc 3.36.0.3 -> 3.49.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation 'joda-time:joda-time:2.10.13'
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
Bumps the SQLite JDBC driver from `3.36.0.3` to `3.49.1.0`. This is a driver-only upgrade — the project uses SQLite (`dev.db`) via Flyway migrations and MyBatis, and no application or test code changes were required.

```diff
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
```

## API changes
None. `sqlite-jdbc` is consumed only through the standard JDBC API (via Hikari/MyBatis/Flyway), so the version jump required no source migration.

## Notes / why
- Single declaration in `build.gradle:70`; no other co-versioned artifacts.
- The DGS platform BOM only expresses `prefer 3.31.1`, so the explicit coordinate wins. Verified with `./gradlew dependencyInsight --dependency sqlite-jdbc`, which resolves `org.xerial:sqlite-jdbc:3.49.1.0`.
- Full backend suite green: `./gradlew clean test -x jacocoTestCoverageVerification` → 68 tests, 0 failures (matches the pre-upgrade baseline). Flyway migrations and MyBatis mapper tests run against real SQLite and pass unchanged.
- `./gradlew spotlessApply` applied (no formatting changes to the committed file).

Link to Devin session: https://app.devin.ai/sessions/d307aec9b34340b9b5684e5dd1346a55
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->