### PR TITLE
Upgrade Mockito to 5.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+// Override Spring Boot BOM-pinned versions so Mockito 5.x resolves correctly.
+ext['mockito.version'] = '5.18.0'
+ext['byte-buddy.version'] = '1.17.5'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {
@@ -79,7 +83,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'


### PR DESCRIPTION
## Summary
Upgrades Mockito `4.0.0 -> 5.18.0`. Mockito's version is pinned by the Spring Boot 2.6.3 BOM, so a plain coordinate change would be silently overridden — the bump is forced via Gradle property overrides in `build.gradle`. `mockito-inline` no longer exists in Mockito 5 (the inline mock maker is now the default), so it is replaced by `mockito-core` + `mockito-junit-jupiter`.

## Changes (`build.gradle`)
- BOM overrides so Mockito 5 resolves instead of the BOM-pinned 4.0.0, and a matching byte-buddy required by Mockito 5:
  ```gradle
  ext['mockito.version'] = '5.18.0'
  ext['byte-buddy.version'] = '1.17.5'
  ```
- Dependency swap:
  ```diff
  - testImplementation 'org.mockito:mockito-inline:4.0.0'
  + testImplementation 'org.mockito:mockito-core'
  + testImplementation 'org.mockito:mockito-junit-jupiter'
  ```

## API changes
- None. All test usages are the stable static API (`Mockito.when/verify`, `ArgumentMatchers.*`); no source migration was required.

## Notes / why
- `byte-buddy` is bumped to `1.17.5` because Mockito 5.18.0 requires a newer byte-buddy than the Spring Boot BOM pins; without it mocking fails at runtime on Java 11.
- Verified resolution with `./gradlew dependencyInsight --dependency mockito-core --configuration testRuntimeClasspath` → `org.mockito:mockito-core:5.18.0` (byte-buddy → `1.17.5`).
- `./gradlew clean test -x jacocoTestCoverageVerification` passes all 68 tests (baseline unchanged); `spotlessApply` is clean. Scope limited to the Mockito upgrade — no other dependency touched.

Link to Devin session: https://app.devin.ai/sessions/26bb01f7c975495e8e7817ae5ed5df1c
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->