### PR TITLE
Upgrade httpclient5 from 5.2.1 to 5.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
     testImplementation 'org.testng:testng:7.8.0'
     testImplementation 'com.aventstack:extentreports:5.1.1'
-    testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+    testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.6.1'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## Summary
Bumps the Selenium E2E test dependency `org.apache.httpcomponents.client5:httpclient5` from `5.2.1` to `5.6.1` in `build.gradle`. This is the only change.

```diff
- testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+ testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.6.1'
```

## API changes
None. `grep -rn 'org.apache.hc' src` returns no matches — the project has no direct usages of the httpclient5 API; it's pulled in transitively for the Selenium WebDriver stack. No source migration was required.

## Notes / why
- Not Spring Boot BOM-managed here, so editing the coordinate is sufficient. `./gradlew dependencyInsight --dependency httpclient5 --configuration testRuntimeClasspath` confirms `5.6.1 (selected by rule)`, also overriding webdrivermanager's transitive `5.0.3 -> 5.6.1`.
- `./gradlew assemble` + `compileTestJava` compile cleanly.
- `./gradlew clean test -x jacocoTestCoverageVerification` passes with **68 tests, 0 failures** (matches baseline).
- Scoped strictly to this dependency — no other deps touched, no unrelated formatting committed.

Link to Devin session: https://app.devin.ai/sessions/4d90ffbd054f465e9c833c0a80978655
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->