### PR TITLE
Upgrade org.testng:testng 7.8.0 -> 7.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
-    testImplementation 'org.testng:testng:7.8.0'
+    testImplementation 'org.testng:testng:7.11.0'
     testImplementation 'com.aventstack:extentreports:5.1.1'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 }


### PR DESCRIPTION
## Summary
Bumps the Selenium E2E test dependency `org.testng:testng` from `7.8.0` to `7.11.0`. This is the only change.

```diff
- testImplementation 'org.testng:testng:7.8.0'
+ testImplementation 'org.testng:testng:7.11.0'
```

## API changes
None required. The Selenium suite (`src/test/java/io/spring/selenium/**`) only uses stable TestNG APIs that are unchanged across 7.8→7.11: `ITestContext`, `ITestListener`, `ITestResult`, `org.testng.annotations.*`, and `org.testng.Assert.*`. No source changes were needed to compile.

## Validation
| Check | Result |
|-------|--------|
| `dependencyInsight --dependency testng` | Resolves `7.11.0` (not BOM-pinned) |
| `./gradlew assemble compileTestJava` | ✅ Compiles cleanly |
| `./gradlew clean test -x jacocoTestCoverageVerification` | ✅ 68/68 tests pass (matches baseline) |
| `./gradlew spotlessApply` | Only reformatted pre-existing formatting debt in unrelated files; reverted to keep PR scoped |
| CI (build + SonarCloud + Devin Review) | ✅ All green |

## `seleniumTest` runtime note — Gradle 7.4 incompatibility
Running `./gradlew seleniumTest` with TestNG 7.11.0 on Gradle 7.4 fails **before** tests execute:

```
Caused by: org.gradle.internal.reflect.NoSuchMethodException:
  Could not find method isEnabled() on TestNGTestResultProcessorAdapter.
  at org.gradle.api.internal.tasks.testing.testng.TestNGListenerAdapterFactory$AdaptedListener.invoke
  at org.testng.TestNG.addListener(TestNG.java:734)
```

Verified this is **not** pre-existing: the same `./gradlew seleniumTest` with TestNG 7.8.0 passes the adapter stage and proceeds to browser launch (it then fails because no launchable Chrome binary is available in this environment, which is expected).

**Root cause:** TestNG 7.11.0's `TestNG.addListener()` calls `isEnabled()` on the listener proxy. Gradle 7.4's `TestNGListenerAdapterFactory$AdaptedListener` creates a dynamic proxy that doesn't delegate `isEnabled()`. This is fixed in Gradle 8.x.

**Options:**
1. Upgrade the Gradle wrapper to 8.x (recommended if Java 11 is still targeted; Gradle 8.0+ supports Java 11 and handles modern TestNG).
2. Stay on TestNG 7.8.0 until Gradle is upgraded.
3. Accept the bump now — the `seleniumTest` task is excluded from CI (`test` task uses JUnit 5), so nothing breaks in practice. Fix `seleniumTest` when upgrading Gradle.


Link to Devin session: https://app.devin.ai/sessions/23623ecea7e34ffdbda5a097b09c0ab2
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->