### PR TITLE
Upgrade MyBatis Spring Boot Starter 2.2.2 -> 2.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.2'
     implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
     implementation 'org.flywaydb:flyway-core'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
@@ -78,7 +78,7 @@ dependencies {
     testImplementation 'io.rest-assured:spring-mock-mvc:4.5.1'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.2'
     testImplementation 'org.mockito:mockito-inline:4.0.0'
     
     // Selenium E2E testing


### PR DESCRIPTION
## Summary
The requested target, `mybatis-spring-boot-starter:3.0.4`, is **not viable** on this stack: per the [official compatibility matrix](https://mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/), the 3.0.x line requires **Spring Boot 3.2–3.5 and Java 17+** (it uses Spring 6 / the `jakarta.*` namespace). This repo is Spring Boot 2.6.3 / Java 11, so adopting 3.0.4 would require a full Spring Boot 3 + Java 17 migration, which is out of scope.

Instead, this PR bumps to the **highest version compatible with Spring Boot 2.6.3 / Java 11**: `2.3.2` (the latest in the `2.x` line; 2.3.x targets Spring Boot 2.7 / Java 8+ and resolves cleanly against 2.6.3).

```diff
- org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2
+ org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.2
- org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2
+ org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.2
```

## API changes
- None. No source changes were needed — the 2.2 → 2.3 bump is non-breaking for this codebase (XML mappers + `@MybatisTest` usage are unchanged).

## Notes / why
- `mybatis-spring-boot-starter` is **not** managed by the Spring Boot BOM, so the coordinate bump takes effect directly. Verified via `dependencyInsight`: `mybatis-spring-boot-starter:2.3.2` resolves on `testRuntimeClasspath`.
- Full suite is green and matches the pre-upgrade baseline: `./gradlew clean test -x jacocoTestCoverageVerification` → **68 tests, 0 failures, 0 errors** (same as before the bump).
- No other dependency was touched; Spring Boot (2.6.3) and Java (11) are unchanged.
- `spotlessApply` was run; it only reformatted unrelated pre-existing Selenium files (not part of this change), so those were left out of the commit to keep the diff scoped.


Link to Devin session: https://app.devin.ai/sessions/63f44df522904879a5e0addea9ee2f67
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->