### PR TITLE
Upgrade webdrivermanager from 5.6.2 to 6.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
-    testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
+    testImplementation 'io.github.bonigarcia:webdrivermanager:6.1.0'
     testImplementation 'org.testng:testng:7.8.0'
     testImplementation 'com.aventstack:extentreports:5.1.1'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'


### PR DESCRIPTION
## Summary
Upgrades the Selenium E2E test dependency `io.github.bonigarcia:webdrivermanager` from `5.6.2` → `6.1.0` (a major version bump). This is a single-line change in `build.gradle` under the Selenium E2E `testImplementation` block — no other dependency is touched.

```diff
- testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
+ testImplementation 'io.github.bonigarcia:webdrivermanager:6.1.0'
```

## API changes
None required. The only WebDriverManager API surface used in this repo (`io/spring/selenium/tests/BaseTest.java`) is the manager factory + `setup()` pattern:

```java
WebDriverManager.chromedriver().setup();
WebDriverManager.firefoxdriver().setup();
WebDriverManager.edgedriver().setup();
```

These methods are unchanged in 6.x, so no source migration was needed. `grep -rn 'io.github.bonigarcia' src` shows no other usages.

## Notes / verification
- `webdrivermanager` is not Spring Boot BOM-managed, so the bump resolves directly — `dependencyInsight --configuration testRuntimeClasspath` confirms `6.1.0 (selected by rule)`, no BOM downgrade.
- `./gradlew assemble compileTestJava` compiles cleanly (main + test).
- `./gradlew clean test -x jacocoTestCoverageVerification` passes — 68 tests, matching the pre-upgrade baseline. The Selenium suite (`io/spring/selenium/**`) is excluded from the `test` task and runs separately via `seleniumTest` (needs a browser); CI only runs the main `test` task.
- Spotless: running `spotlessApply` only reformats pre-existing, unrelated style violations in the Selenium test files; since no source was changed for this upgrade and CI does not run `spotlessCheck`, those unrelated reformats were intentionally left out to keep this PR focused on the version bump.


Link to Devin session: https://app.devin.ai/sessions/21a7bdf9c3be4b2cae46cbd38806610c
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->