### PR TITLE
Upgrade selenium-java from 4.15.0 to 4.33.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 targetCompatibility = '11'
 
+// Spring Boot's dependency-management BOM pins the selenium-* submodules; override
+// so selenium-java and all its submodules resolve to the desired version.
+ext['selenium.version'] = '4.33.0'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:4.0.0'
     
     // Selenium E2E testing
-    testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-java:4.33.0'
     testImplementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
     testImplementation 'org.testng:testng:7.8.0'
     testImplementation 'com.aventstack:extentreports:5.1.1'

--- a/src/test/java/io/spring/selenium/pages/BasePage.java
+++ b/src/test/java/io/spring/selenium/pages/BasePage.java
@@ -1,5 +1,6 @@
 package io.spring.selenium.pages;
 
+import java.time.Duration;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.PageFactory;
@@ -17,7 +18,7 @@ public abstract class BasePage {
     
     public BasePage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT_SECONDS);
+        this.wait = new WebDriverWait(driver, Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS));
         PageFactory.initElements(driver, this);
     }
     


### PR DESCRIPTION
## Summary
Upgrades the Selenium E2E test dependency from `4.15.0` to `4.33.0`. Two changes are required to make the bump *actually* effective and compile:

1. **Bump + BOM override** in `build.gradle`. Spring Boot 2.6.3's dependency-management BOM pins the Selenium **submodules** (`selenium-api`, `selenium-chrome-driver`, `selenium-remote-driver`, `selenium-support`) to `3.141.59`. `selenium-java` is only an aggregator POM, so bumping that coordinate alone left the real classes at `3.141.59`. An `ext` property override forces all submodules to `4.33.0`.

```diff
+ ext['selenium.version'] = '4.33.0'
  ...
- testImplementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
+ testImplementation 'org.seleniumhq.selenium:selenium-java:4.33.0'
```

2. **API migration** in `src/test/.../selenium/pages/BasePage.java`. Selenium 4 removed the `WebDriverWait(WebDriver, long)` constructor; it now requires a `Duration`.

```diff
- this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT_SECONDS);
+ this.wait = new WebDriverWait(driver, Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS));
```

## Notes / verification
- `dependencyInsight` / `dependencies` on `testRuntimeClasspath` confirm every `selenium-*` artifact resolves to `4.33.0` (BOM no longer downgrades them).
- `./gradlew assemble` + `./gradlew compileTestJava` succeed on **Java 11** (`JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64`); Selenium 4.33.0 runs fine on Java 11.
- `./gradlew clean test -x jacocoTestCoverageVerification` passes with **68 tests, 0 failures** (matches baseline). Selenium tests (`io/spring/selenium/**`) stay excluded from `test` and run via the separate `seleniumTest` task.
- Runtime `seleniumTest` could not be fully exercised in this environment: ChromeDriver 4.33 launches but the sandbox's `google-chrome` is a Devin browser wrapper, not a standalone Chrome binary, so a fresh WebDriver session can't be created (`SessionNotCreatedException`). This is an environment limitation, not a code issue.
- `webdrivermanager:5.6.2` left unchanged per scope ("upgrade ONLY selenium-java"); it is version-resilient and only affects runtime driver download.
- Only `build.gradle` + the one-line `BasePage.java` API fix are touched. CI (`gradle.yml`) runs only `clean test` and does not invoke `spotlessCheck`.


Link to Devin session: https://app.devin.ai/sessions/07fe825d5e684b01b12623c6b987cfc8
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->