### PR TITLE
Upgrade Netflix DGS starter from 4.9.21 to 5.6.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
-    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
+    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:5.6.2'
     implementation 'org.flywaydb:flyway-core'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',


### PR DESCRIPTION
## Summary
Bumps `com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter` from `4.9.21` to **`5.6.2`** — the highest DGS version compatible with this repo's **Spring Boot 2.6.3 / Java 11** stack.

```diff
- implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
+ implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:5.6.2'
```

The originally-requested target **`9.2.2` is not achievable without a full Spring Boot 3 + Java 17 migration** (explicitly out of scope), so this PR upgrades to the safe ceiling instead.

## Why not 9.2.2 (and why 5.6.2 is the ceiling)
- DGS `9.2.2` is published with **Java 17** metadata. On Java 11, Gradle refuses to resolve it: *"this component declares a component compatible with Java 17 and the consumer needed a component compatible with Java 11."* DGS 6.x+ targets Spring Boot 3.x / Java 17.
- `5.6.2` is the last DGS `5.x` release (Java 8 bytecode, compatible with Java 11). Its BOM references Spring Boot 2.7.5, but this project's Spring Boot 2.6.3 dependency-management BOM wins — `dependencyInsight` confirms `org.springframework.boot:spring-boot` resolves to **2.6.3** (no framework bump) while the starter resolves to **5.6.2**.

## API changes
- **None.** All DGS APIs used by the app (`@DgsComponent`, `@DgsData`, `@DgsQuery`, `@DgsMutation`, `@InputArgument`, `DgsDataFetchingEnvironment`, `TypedGraphQLError`, `ErrorType`, `DefaultDataFetcherExceptionHandler`) are unchanged between 4.9 and 5.6, so no source edits were required.

## Notes
- The DGS codegen Gradle plugin (`com.netflix.dgs.codegen` 5.0.6) was left untouched — it builds and generates `io.spring.graphql.*` types that work against the 5.6.2 runtime, so no sync was needed. No other dependency was touched.
- Verified locally on Java 11: `./gradlew clean test -x jacocoTestCoverageVerification` → **BUILD SUCCESSFUL, 68 tests, 0 failures** (matches pre-upgrade baseline, including the GraphQL datafetcher/mutation tests).


Link to Devin session: https://app.devin.ai/sessions/de5c17dfe2114b90bc98bf8f98e3c7bd
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->