### PR TITLE
chore: upgrade Spring Boot to 3.5.0 and Java to 21

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: '11'
+        java-version: '21'
     - uses: actions/cache@v4
       with:
         path: |

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version '2.6.3'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.springframework.boot' version '3.5.0'
+    id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
     id "com.netflix.dgs.codegen" version "5.0.6"
     id "com.diffplug.spotless" version "6.2.1"
@@ -8,8 +8,8 @@ plugins {
 }
 
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
-targetCompatibility = '11'
+sourceCompatibility = '21'
+targetCompatibility = '21'
 
 spotless {
     java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

Sets the version baseline for the Spring Boot 3.x migration by bumping plugin versions, Java level, and Gradle wrapper:

```diff
# build.gradle plugins block
- id 'org.springframework.boot' version '2.6.3'
+ id 'org.springframework.boot' version '3.5.0'
- id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+ id 'io.spring.dependency-management' version '1.1.7'

# build.gradle compatibility
- sourceCompatibility = '11'
+ sourceCompatibility = '21'
- targetCompatibility = '11'
+ targetCompatibility = '21'

# gradle-wrapper.properties
- gradle-7.4-bin.zip
+ gradle-8.14.1-bin.zip

# .github/workflows/gradle.yml
- java-version: '11'
+ java-version: '21'
```

The Gradle wrapper upgrade (7.4 → 8.14.1) is required because Gradle 7.x does not support Java 21 class files (major version 65).

**CI will still fail at compilation** — this is expected. The codebase still uses `javax.*` imports, `WebSecurityConfigurerAdapter`, and other patterns removed in Spring Boot 3.x. Those migrations (javax→jakarta, Security config rewrite, DGS upgrade, JJWT API changes) are separate follow-up tasks that build on this version baseline.

Link to Devin session: https://app.devin.ai/sessions/d1ff88771a764d3eb62606af248ede01
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->