### PR TITLE
Upgrade mybatis-spring-boot-starter family 2.2.2 -> 2.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.2'
     implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
     implementation 'org.flywaydb:flyway-core'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
@@ -78,7 +78,7 @@ dependencies {
     testImplementation 'io.rest-assured:spring-mock-mvc:4.5.1'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.2'
     testImplementation 'org.mockito:mockito-inline:4.0.0'
     
     // Selenium E2E testing


### PR DESCRIPTION
## Summary
Bumps the MyBatis Spring Boot starter family from `2.2.2` to `2.3.2` (latest `2.x`):

```diff
- org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2        (implementation)
+ org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.2
- org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2   (testImplementation)
+ org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.2
```

**Why capped at 2.3.x:** the `3.x` line requires MyBatis-Spring 3.0, **Java 17 and Spring Boot 3.0+**. This repo stays on **Spring Boot 2.6.3 / Java 11**, so `2.3.2` (released 2023-11-25) is the newest compatible release. The `2.3.x` line targets MyBatis-Spring 2.1, Java 8+, Spring Boot 2.5–2.7.

**Changes:** dependency declarations only — no source/API changes were required. MyBatis-Spring `2.0 -> 2.1` introduced no breaking changes affecting this app's XML mappers (`src/main/resources/mapper/*.xml`) or `@MybatisTest` usage.

**Verification (Java 11):**
- `dependencyInsight` confirms `2.3.2` resolved on both `runtimeClasspath` and `testRuntimeClasspath` (no Spring Boot BOM downgrade — the starter version is set explicitly, not BOM-managed).
- `./gradlew assemble` succeeds.
- `./gradlew clean test -x jacocoTestCoverageVerification` — **68/68 pass** (matches baseline).
- `./gradlew spotlessCheck` clean.

Link to Devin session: https://app.devin.ai/sessions/fa6564b7bd264b5297e8d4968c4f6883
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->