### PR TITLE
Upgrade sqlite-jdbc from 3.36.0.3 to 3.49.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation 'joda-time:joda-time:2.10.13'
-    implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+    implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
Bumps the SQLite JDBC driver to the latest stable release that still supports Java 11 (this repo is pinned to Spring Boot 2.6.3 / Java 11).

```diff
- implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
+ implementation 'org.xerial:sqlite-jdbc:3.49.1.0'
```

**Why 3.49.1.0:** it is the newest `org.xerial:sqlite-jdbc` release that still targets Java 8+ (jar class version 52, OSGi `Require-Capability` `JavaSE 1.8`), so it remains compatible with the Java 11 toolchain. No newer version drops Java 11 support, so this is simply "latest stable".

## Notes
- **No source changes needed.** `sqlite-jdbc` is not managed by the Spring Boot BOM, so the coordinate bump takes effect directly — `dependencyInsight --dependency sqlite-jdbc --configuration testRuntimeClasspath` confirms it resolves to `3.49.1.0` (a DGS platform `prefer 3.31.1` constraint does not override it).
- The DB layer (MyBatis + Flyway against a file-based SQLite `dev.db`) is unaffected: the full suite — including the `@MybatisTest` tests that run against real SQLite — passes **68/68** with `./gradlew clean test -x jacocoTestCoverageVerification`. No SQL/type-mapping behavior changes surfaced.
- `spotlessCheck` is clean.
- Scope limited to `build.gradle`; no other dependencies touched.


Link to Devin session: https://app.devin.ai/sessions/1eca802f4a644d3fbff67a6e4ed949a0
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->