### PR TITLE
Upgrade joda-time from 2.10.13 to 2.14.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
                 'io.jsonwebtoken:jjwt-jackson:0.11.2'
-    implementation 'joda-time:joda-time:2.10.13'
+    implementation 'joda-time:joda-time:2.14.2'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
Bumps the `joda-time` dependency to the latest stable release.

```diff
- implementation 'joda-time:joda-time:2.10.13'
+ implementation 'joda-time:joda-time:2.14.2'
```

2.14.2 is the latest stable joda-time on Maven Central (the 2.1x line is API-compatible with 2.10.x — these releases are tz-database/data and minor fixes). No `org.joda.time` API usage in `src/main` or `src/test` required changes.

## Notes
- Single-line change to `build.gradle`; no other dependencies, Spring Boot (2.6.3), Gradle plugins, or the Java 11 toolchain were touched.
- joda-time is **not** Spring Boot BOM-managed here, so no `ext['joda-time.version']` override was needed — `dependencyInsight` confirms `joda-time:2.14.2` resolves on `testRuntimeClasspath`.
- Full backend suite green: `./gradlew clean test -x jacocoTestCoverageVerification` → 68 tests, 0 failures (baseline preserved). `spotlessApply` produced no changes to the bumped file.


Link to Devin session: https://app.devin.ai/sessions/b67be9528af54ae6823d901436927511
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->