### PR TITLE
Upgrade jjwt 0.11.2 -> 0.12.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
     implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
     implementation 'org.flywaydb:flyway-core'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
-                'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7',
+                'io.jsonwebtoken:jjwt-jackson:0.12.7'
     implementation 'joda-time:joda-time:2.10.13'
     implementation 'org.xerial:sqlite-jdbc:3.36.0.3'
 

--- a/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
+++ b/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
@@ -3,7 +3,6 @@ package io.spring.infrastructure.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
 import java.util.Date;
@@ -17,32 +16,29 @@ import org.springframework.stereotype.Component;
 @Component
 public class DefaultJwtService implements JwtService {
   private final SecretKey signingKey;
-  private final SignatureAlgorithm signatureAlgorithm;
   private int sessionTime;
 
   @Autowired
   public DefaultJwtService(
       @Value("${jwt.secret}") String secret, @Value("${jwt.sessionTime}") int sessionTime) {
     this.sessionTime = sessionTime;
-    signatureAlgorithm = SignatureAlgorithm.HS512;
-    this.signingKey = new SecretKeySpec(secret.getBytes(), signatureAlgorithm.getJcaName());
+    this.signingKey = new SecretKeySpec(secret.getBytes(), "HmacSHA512");
   }
 
   @Override
   public String toToken(User user) {
     return Jwts.builder()
-        .setSubject(user.getId())
-        .setExpiration(expireTimeFromNow())
-        .signWith(signingKey)
+        .subject(user.getId())
+        .expiration(expireTimeFromNow())
+        .signWith(signingKey, Jwts.SIG.HS512)
         .compact();
   }
 
   @Override
   public Optional<String> getSubFromToken(String token) {
     try {
-      Jws<Claims> claimsJws =
-          Jwts.parserBuilder().setSigningKey(signingKey).build().parseClaimsJws(token);
-      return Optional.ofNullable(claimsJws.getBody().getSubject());
+      Jws<Claims> claimsJws = Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token);
+      return Optional.ofNullable(claimsJws.getPayload().getSubject());
     } catch (Exception e) {
       return Optional.empty();
     }

--- a/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
+++ b/src/main/java/io/spring/infrastructure/service/DefaultJwtService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.spring.core.service.JwtService;
 import io.spring.core.user.User;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Optional;
 import javax.crypto.SecretKey;
@@ -22,7 +23,7 @@ public class DefaultJwtService implements JwtService {
   public DefaultJwtService(
       @Value("${jwt.secret}") String secret, @Value("${jwt.sessionTime}") int sessionTime) {
     this.sessionTime = sessionTime;
-    this.signingKey = new SecretKeySpec(secret.getBytes(), "HmacSHA512");
+    this.signingKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA512");
   }
 
   @Override

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -37,7 +37,8 @@ public class DefaultJwtServiceTest {
   @Test
   public void should_get_null_with_expired_jwt() {
     String token =
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhaXNlbnNpeSIsImV4cCI6MTUwMjE2MTIwNH0.SJB-U60WzxLYNomqLo4G3v3LzFxJKuVrIud8D8Lz3-mgpo9pN1i7C8ikU_jQPJGm8HsC1CquGMI-rSuM7j6LDA";
+        "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhaXNlbnNpeSIsImV4cCI6MTUwMjE2MTIwNH0"
+            + ".wSdCB-GsORubLR-RozPFWpAPwNr0QFg3t9PlSeTUdtd1pR9u1WK6Os7a9H6CAxSvcJ8uL5Tu3sERBtDPqzHHbw";
     Assertions.assertFalse(jwtService.getSubFromToken(token).isPresent());
   }
 }

--- a/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
+++ b/src/test/java/io/spring/infrastructure/service/DefaultJwtServiceTest.java
@@ -14,7 +14,8 @@ public class DefaultJwtServiceTest {
   @BeforeEach
   public void setUp() {
     jwtService =
-        new DefaultJwtService("123123123123123123123123123123123123123123123123123123123123", 3600);
+        new DefaultJwtService(
+            "12312312312312312312312312312312312312312312312312312312312312312312", 3600);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Upgrades the jjwt dependency family and migrates `DefaultJwtService` to the jjwt 0.12 API. 0.12.7 is the latest stable 0.12.x release (0.13.0 is a separate minor and out of scope). Production JWTs remain HS512-signed; only the API surface changed.

**Artifacts (`build.gradle`), all moved together `0.11.2 -> 0.12.7`:**
- `io.jsonwebtoken:jjwt-api`
- `io.jsonwebtoken:jjwt-impl`
- `io.jsonwebtoken:jjwt-jackson`

**API migration in `DefaultJwtService`:**
- `Jwts.builder().setSubject(..).setExpiration(..)` -> `.subject(..).expiration(..)`
- `.signWith(key)` -> `.signWith(key, Jwts.SIG.HS512)` (explicit algorithm; replaces the now-deprecated `SignatureAlgorithm.HS512`)
- `Jwts.parserBuilder().setSigningKey(key)` -> `Jwts.parser().verifyWith(key)`
- `parseClaimsJws(..)` -> `parseSignedClaims(..)`; `claimsJws.getBody()` -> `.getPayload()`
- key construction: `new SecretKeySpec(secret.getBytes(), signatureAlgorithm.getJcaName())` -> `new SecretKeySpec(secret.getBytes(), "HmacSHA512")` after dropping the `SignatureAlgorithm` field.

## Notes / non-obvious decisions
- **RFC 7518 key-size enforcement.** jjwt 0.12 rejects HS512 keys shorter than 512 bits. The production secret (`jwt.secret`, 85 bytes / 680 bits) already satisfies this, so production behavior is unchanged. The unit test in `DefaultJwtServiceTest` used a 60-byte (480-bit) dummy secret that 0.11 accepted but 0.12 rejects; it was lengthened to 68 bytes so it is a valid HS512 key. The test's assertion/intent (generate a token then parse the subject back) is unchanged.
- Algorithm is kept explicit (`Jwts.SIG.HS512`) rather than relying on jjwt's length-based auto-detection, to guarantee HS512 regardless of key length.
- Scope limited to jjwt; no other dependencies, Spring Boot, Gradle plugins, or the Java 11 toolchain were touched.

## Verification
- `./gradlew assemble` — compiles (Java 11).
- `./gradlew clean test -x jacocoTestCoverageVerification` — **68 passing, 0 failing** (Selenium excluded), matching the pre-upgrade baseline.

Link to Devin session: https://app.devin.ai/sessions/f8f71116a97e48d4a025be3cfc9625ae
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->