### PR TITLE
Upgrade Mockito 4.0.0 -> 5.23.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ targetCompatibility = '11'
 // Override the managed property so all selenium-* artifacts resolve to 4.45.0.
 ext['selenium.version'] = '4.45.0'
 
+// Spring Boot 2.6.3's BOM pins Mockito to ~4.0.0 and byte-buddy to an older version.
+// Override the managed properties so Mockito 5.x and its required byte-buddy resolve.
+ext['mockito.version'] = '5.23.0'
+ext['byte-buddy.version'] = '1.17.7'
+
 spotless {
     java {
         target project.fileTree(project.rootDir) {
@@ -84,7 +89,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.2'
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
     
     // Selenium E2E testing
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.45.0'


### PR DESCRIPTION
## Summary
Upgrades Mockito from `4.0.0` to the latest stable `5.23.0` (test scope only). Spring Boot 2.6.3 and Java 11 are unchanged; Mockito 5 requires Java 11+, which is satisfied.

Two things make this more than a version bump:

1. **`mockito-inline` is removed in Mockito 5** — the inline mock maker is now the default. The single dependency is replaced with `mockito-core` + `mockito-junit-jupiter`:
   ```diff
   - testImplementation 'org.mockito:mockito-inline:4.0.0'
   + testImplementation 'org.mockito:mockito-core'
   + testImplementation 'org.mockito:mockito-junit-jupiter'
   ```

2. **Spring Boot's BOM pins Mockito (~4.0.0) and byte-buddy**, so editing the coordinate alone is overridden by dependency management. Overridden via Gradle properties so the new versions actually resolve:
   ```gradle
   ext['mockito.version'] = '5.23.0'
   ext['byte-buddy.version'] = '1.17.7'   // Mockito 5.23.0 requires byte-buddy 1.17.7
   ```
   Verified with `dependencyInsight`: `mockito-core 4.0.0 -> 5.23.0` and `byte-buddy 1.18.10 -> 1.17.7` (BOM no longer downgrading).

## API changes
None required. The only Mockito API used in `src/test` is `Mockito.when` / `Mockito.verify` / `ArgumentMatchers.*`, all unchanged in v5. No test logic was modified.

## Verification
- `./gradlew assemble` — success
- `./gradlew clean test -x jacocoTestCoverageVerification` — 68 tests, 0 failures (matches baseline)
- `./gradlew spotlessCheck` — clean

Link to Devin session: https://app.devin.ai/sessions/b0e18734e3324de2b1d6a2a70b551692
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->