### PR TITLE
Upgrade Netflix DGS 4.9.21 -> 5.5.5 and codegen plugin 5.0.6 -> 5.12.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
-    id "com.netflix.dgs.codegen" version "5.0.6"
+    id "com.netflix.dgs.codegen" version "5.12.4"
     id "com.diffplug.spotless" version "6.2.1"
     id 'jacoco'
 }
@@ -66,7 +66,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
-    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:4.9.21'
+    implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter:5.5.5'
     implementation 'org.flywaydb:flyway-core'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',

--- a/src/main/java/io/spring/graphql/ArticleDatafetcher.java
+++ b/src/main/java/io/spring/graphql/ArticleDatafetcher.java
@@ -6,8 +6,6 @@ import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import com.netflix.graphql.dgs.DgsQuery;
 import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
-import graphql.relay.DefaultConnectionCursor;
-import graphql.relay.DefaultPageInfo;
 import graphql.schema.DataFetchingEnvironment;
 import io.spring.api.exception.ResourceNotFoundException;
 import io.spring.application.ArticleQueryService;
@@ -26,6 +24,7 @@ import io.spring.graphql.DgsConstants.QUERY;
 import io.spring.graphql.types.Article;
 import io.spring.graphql.types.ArticleEdge;
 import io.spring.graphql.types.ArticlesConnection;
+import io.spring.graphql.types.PageInfo;
 import io.spring.graphql.types.Profile;
 import java.util.HashMap;
 import java.util.stream.Collectors;
@@ -64,7 +63,7 @@ public class ArticleDatafetcher {
               current,
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV));
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -114,7 +113,7 @@ public class ArticleDatafetcher {
               target,
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV));
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -167,7 +166,7 @@ public class ArticleDatafetcher {
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV),
               current);
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
 
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
@@ -221,7 +220,7 @@ public class ArticleDatafetcher {
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV),
               current);
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -276,7 +275,7 @@ public class ArticleDatafetcher {
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV),
               current);
     }
-    graphql.relay.PageInfo pageInfo = buildArticlePageInfo(articles);
+    PageInfo pageInfo = buildArticlePageInfo(articles);
     ArticlesConnection articlesConnection =
         ArticlesConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -356,16 +355,12 @@ public class ArticleDatafetcher {
         .build();
   }
 
-  private DefaultPageInfo buildArticlePageInfo(CursorPager<ArticleData> articles) {
-    return new DefaultPageInfo(
-        articles.getStartCursor() == null
-            ? null
-            : new DefaultConnectionCursor(articles.getStartCursor().toString()),
-        articles.getEndCursor() == null
-            ? null
-            : new DefaultConnectionCursor(articles.getEndCursor().toString()),
+  private PageInfo buildArticlePageInfo(CursorPager<ArticleData> articles) {
+    return new PageInfo(
+        articles.getEndCursor() == null ? null : articles.getEndCursor().toString(),
+        articles.hasNext(),
         articles.hasPrevious(),
-        articles.hasNext());
+        articles.getStartCursor() == null ? null : articles.getStartCursor().toString());
   }
 
   private Article buildArticleResult(ArticleData articleData) {

--- a/src/main/java/io/spring/graphql/CommentDatafetcher.java
+++ b/src/main/java/io/spring/graphql/CommentDatafetcher.java
@@ -5,8 +5,6 @@ import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import com.netflix.graphql.dgs.InputArgument;
 import graphql.execution.DataFetcherResult;
-import graphql.relay.DefaultConnectionCursor;
-import graphql.relay.DefaultPageInfo;
 import io.spring.application.CommentQueryService;
 import io.spring.application.CursorPageParameter;
 import io.spring.application.CursorPager;
@@ -21,6 +19,7 @@ import io.spring.graphql.types.Article;
 import io.spring.graphql.types.Comment;
 import io.spring.graphql.types.CommentEdge;
 import io.spring.graphql.types.CommentsConnection;
+import io.spring.graphql.types.PageInfo;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -78,7 +77,7 @@ public class CommentDatafetcher {
               current,
               new CursorPageParameter<>(DateTimeCursor.parse(before), last, Direction.PREV));
     }
-    graphql.relay.PageInfo pageInfo = buildCommentPageInfo(comments);
+    PageInfo pageInfo = buildCommentPageInfo(comments);
     CommentsConnection result =
         CommentsConnection.newBuilder()
             .pageInfo(pageInfo)
@@ -99,16 +98,12 @@ public class CommentDatafetcher {
         .build();
   }
 
-  private DefaultPageInfo buildCommentPageInfo(CursorPager<CommentData> comments) {
-    return new DefaultPageInfo(
-        comments.getStartCursor() == null
-            ? null
-            : new DefaultConnectionCursor(comments.getStartCursor().toString()),
-        comments.getEndCursor() == null
-            ? null
-            : new DefaultConnectionCursor(comments.getEndCursor().toString()),
+  private PageInfo buildCommentPageInfo(CursorPager<CommentData> comments) {
+    return new PageInfo(
+        comments.getEndCursor() == null ? null : comments.getEndCursor().toString(),
+        comments.hasNext(),
         comments.hasPrevious(),
-        comments.hasNext());
+        comments.getStartCursor() == null ? null : comments.getStartCursor().toString());
   }
 
   private Comment buildCommentResult(CommentData comment) {

--- a/src/main/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandler.java
+++ b/src/main/java/io/spring/graphql/exception/GraphQLCustomizeExceptionHandler.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -28,7 +29,7 @@ public class GraphQLCustomizeExceptionHandler implements DataFetcherExceptionHan
       new DefaultDataFetcherExceptionHandler();
 
   @Override
-  public DataFetcherExceptionHandlerResult onException(
+  public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(
       DataFetcherExceptionHandlerParameters handlerParameters) {
     if (handlerParameters.getException() instanceof InvalidAuthenticationException) {
       GraphQLError graphqlError =
@@ -37,7 +38,8 @@ public class GraphQLCustomizeExceptionHandler implements DataFetcherExceptionHan
               .message(handlerParameters.getException().getMessage())
               .path(handlerParameters.getPath())
               .build();
-      return DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build();
+      return CompletableFuture.completedFuture(
+          DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build());
     } else if (handlerParameters.getException() instanceof ConstraintViolationException) {
       List<FieldErrorResource> errors = new ArrayList<>();
       for (ConstraintViolation<?> violation :
@@ -61,9 +63,10 @@ public class GraphQLCustomizeExceptionHandler implements DataFetcherExceptionHan
               .path(handlerParameters.getPath())
               .extensions(errorsToMap(errors))
               .build();
-      return DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build();
+      return CompletableFuture.completedFuture(
+          DataFetcherExceptionHandlerResult.newResult().error(graphqlError).build());
     } else {
-      return defaultHandler.onException(handlerParameters);
+      return defaultHandler.handleException(handlerParameters);
     }
   }
 


### PR DESCRIPTION
## Summary
Upgrades the Netflix DGS (GraphQL) framework and its codegen Gradle plugin to the latest releases that still target **Spring Boot 2 / Java 11**:

- `com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter`: `4.9.21` -> `5.5.5`
- `com.netflix.dgs.codegen` Gradle plugin: `5.0.6` -> `5.12.4`

**Why capped at 5.5.5:** DGS `6.x+` requires Spring Boot 3 / JDK 17, and the `5.6.x` line is built from the framework's `spring-boot-2.7` branch (targets Spring Boot 2.7). This repo is pinned at Spring Boot 2.6.3 / Java 11, so `5.5.5` is the newest release verified compatible. The `5.5.5` BOM pulls in `graphql-java` `19.5`, which drives the API migrations below. Codegen plugin is kept on the `5.x` line (latest `5.12.4`) so the generated sources stay on `javax`/Java 11.

## API changes
The DGS bump (graphql-java 17 -> 19.5) and the newer codegen output required three source migrations:

- **`GraphQLCustomizeExceptionHandler`** — graphql-java replaced the sync exception hook with an async one:
  ```diff
  - public DataFetcherExceptionHandlerResult onException(params) { ... return result; }
  + public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(params) {
  +   ... return CompletableFuture.completedFuture(result);
  + }
  - return defaultHandler.onException(params);
  + return defaultHandler.handleException(params);
  ```
- **`ArticleDatafetcher` / `CommentDatafetcher`** — codegen `5.12.4` now generates connection builders that take the schema-generated `io.spring.graphql.types.PageInfo` instead of `graphql.relay.PageInfo`. The `buildXPageInfo(...)` helpers now construct the generated type directly from cursor strings, matching the schema field order `PageInfo(endCursor, hasNextPage, hasPreviousPage, startCursor)`:
  ```diff
  - new DefaultPageInfo(startCursorCursor, endCursorCursor, hasPrevious, hasNext)
  + new PageInfo(endCursor, hasNext, hasPrevious, startCursor)
  ```
  Behavior is preserved — same cursor values and boolean flags, just mapped onto the generated POJO.

## Notes
- DGS resolves cleanly to `5.5.5` on the runtime classpath (verified via `dependencyInsight`); it is not overridden by Spring Boot's BOM, so no `ext[...]` override was needed.
- No test logic was changed; only production source was migrated for the new APIs.

## Verification
- `./gradlew clean generateJava assemble` — passes (generated types compile, data fetchers compile).
- `./gradlew clean test -x jacocoTestCoverageVerification` — passes, **68/68** tests (baseline preserved, includes GraphQL tests).
- `./gradlew spotlessApply` / `spotlessCheck` — clean.

(All Gradle runs use `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64`.)

Link to Devin session: https://app.devin.ai/sessions/baf4d41665d44cf3b21c0d345fa957ab
Requested by: @mbatchelor81
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/spring-boot-realworld-example-app/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->